### PR TITLE
 Add ability for Elvis to Delete last sent message 

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "hubot-shipit": "^0.2.0",
     "hubot-slack": "4.5.1",
     "hubot-slack-blacklist-middleware": "^1.0.2",
+    "hubot-slack-utils": "0.0.5",
     "hubot-slack-whitelist-middleware": "^1.0.1",
     "hubot-youtube": "^1.0.2",
     "lodash": "^4.17.4",

--- a/scripts/undo.coffee
+++ b/scripts/undo.coffee
@@ -15,10 +15,10 @@
 #   github.com/Syliddar
 
 module.exports = (robot) ->
-  robot.respond /(delete that)/i, (msg)->
+  robot.respond /delete that/i, (msg)->
     slack delete last 1
     msg.send "Sorry about that."
-  robot.respond /(delete \d)/i, (msg) ->
+  robot.respond /delete (\d)/i, (msg) ->
     lines = msg.match[1]
     slack delete last lines
     msg.send "Sorry about that."

--- a/scripts/undo.coffee
+++ b/scripts/undo.coffee
@@ -1,0 +1,24 @@
+# Description:
+#   Having brought dishonor to it's family. Elvis will delete the last message sent, or the last [n] messages sent
+#
+# Dependencies:
+#   "hubot-slack-utils": "0.0.5",
+#
+# Configuration:
+#   None
+#
+# Commands:
+#   elvis delete that
+#   elvis delete 5
+#
+# Author:
+#   github.com/Syliddar
+
+module.exports = (robot) ->
+  robot.respond /(delete that)/i, (msg)->
+    slack delete last 1
+    msg.send "Sorry about that."
+  robot.respond /(delete \d)/i, (msg) ->
+    lines = msg.match[1]
+    slack delete last lines
+    msg.send "Sorry about that."


### PR DESCRIPTION
usage:
> Elvis Posts a really inappropriate message/link

"Elvis delete that"
Will command Hubot to delete the last message sent in the channel

"Elvis delete [x]"
Will command Hubot to delete the last [x] messages sent in the channel. [x] must be a single-digit numerical value. e.g. "Delete two" will not work. 